### PR TITLE
changed /bin/sh to /bin/bash

### DIFF
--- a/backends/js/build.sh
+++ b/backends/js/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 cd "$(dirname "$0")"
 

--- a/backends/wgpu/mklib.sh
+++ b/backends/wgpu/mklib.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 LLVM_PATH=$("$(dirname "$0")"/../../etc/find-llvm.sh)

--- a/backends/wgpu/setup.sh
+++ b/backends/wgpu/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 cd "$(dirname "$0")"
 

--- a/etc/find-llvm.sh
+++ b/etc/find-llvm.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if command -v wasm-ld >/dev/null; then
   echo "$(dirname $(dirname "$(command -v wasm-ld)"))"

--- a/examples/hello/build.sh
+++ b/examples/hello/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 cd "$(dirname "$0")"
 

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 cd "$(dirname "$0")"
 

--- a/tools/specgen.sh
+++ b/tools/specgen.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 cd "$(dirname "$0")/.."
 


### PR DESCRIPTION
In this pull request, I propose the simple change of all `/bin/sh` to `/bin/bash`, due to problems on Linux. With `/bin/bash`, I'm certain that both MacOS and any Linux distribution will be able to run the helper scripts without editing them.

Some systems do point `sh` to `bash`, but others do not.