### PR TITLE
support for versions and aliases on find-llvm.sh

### DIFF
--- a/etc/find-llvm.sh
+++ b/etc/find-llvm.sh
@@ -1,27 +1,63 @@
-#!/bin/sh
+#!/bin/bash
 
-if command -v wasm-ld >/dev/null; then
-  echo "$(dirname $(dirname "$(command -v wasm-ld)"))"
-  exit 0
+# if LLVM is installed through some package manager such as aptitute,
+# the command wasm-ld is wasm-ld-XX where XX is a LLVM version.
+possible_llvm_vs=(wasm-ld wasm-ld-13 wasm-ld-12 wasm-ld-11 wasm-ld-10)
+has_llvm_wasmld=false
+for pwasm in ${possible_llvm_vs[@]}
+do
+	if (command -v ${pwasm} >/dev/null); then
+  has_llvm_wasmld=true
+	echo "$(dirname $(dirname "$(command -v ${pwasm})"))"
+	fi
+done
+
+if [[ has_llvm_wasmld == false ]]; then
+  echo "LLVM with WASM support not found in PATH."
+  exit 1
 fi
 
+# the clang LLVM compiler will as well be linked to something such as
+# clang-XX where XX is a LLVM version.
+# this step checks if the user has or not clang.
 test_paths=()
-if (command -v clang >/dev/null); then
-  X=$(clang -print-search-dirs | grep programs: | awk '{print $2}' | sed 's/^=//')
-  if [[ "$X" != "" ]]; then
-    test_paths+=( "$(dirname "$X")" )
+has_clang=false
+possible_clang_vs=(clang clang-13 clang-12 clang-11 clang-10)
+for pclang in ${possible_clang_vs[@]}
+do
+	if (command -v ${pclang} >/dev/null); then
+    X=$(${pclang} -print-search-dirs | grep programs: | awk '{print $2}' | sed 's/^=//')
+    if [[ "$X" != "" ]]; then
+      has_clang=true
+      test_paths+=( "$(dirname "$X")" )
+    fi
   fi
+done
+
+if [[ has_clang == false ]]; then
+  echo "CLANG not found in PATH."
+  exit 1
 fi
 
-case $(uname -s) in
-  Darwin*)
-    test_paths+=( \
-      /opt/homebrew/opt/llvm \
-      /usr/local/opt/llvm \
-      /Library/Developer/CommandLineTools/usr \
-    )
-    ;;
-esac
+# for better cross-os identification of LLVM test paths.
+UNAME=$(uname -s)
+if [ "$UNAME" == Linux* ] ; then
+	test_paths+=( \
+    /usr/lib/llvm-13 \
+    /usr/lib/llvm-12 \
+    /usr/lib/llvm-11 \
+    /usr/lib/llvm-10 \
+  )
+elif [ "$UNAME" == Darwin* ] ; then
+	test_paths+=( \
+    /opt/homebrew/opt/llvm \
+    /usr/local/opt/llvm \
+    /Library/Developer/CommandLineTools/usr \
+  )
+elif [[ "$UNAME" == CYGWIN* || "$UNAME" == MINGW* ]] ; then
+	# TODO! add windows test_paths for LLVM.
+  echo ""
+fi
 
 for X in ${test_paths[@]}; do
   # echo "try $X/bin/wasm-ld" >&2


### PR DESCRIPTION
For some package managers suck as `aptitute`, LLVM's `wasm-ld` is installed as `wasm-ld-xx` where `xx` is a version such as 12 or 13. This tweak on `find-llvm.sh` adds support for test paths for Linux, with and without versio numbers.

Also, if the user does not has a command similar to `clang` or `clang-xx`, the script halts and returns an error message with an `exit 1`.